### PR TITLE
Add admin module from node cli for Relay Admin API

### DIFF
--- a/src/admin/requests.js
+++ b/src/admin/requests.js
@@ -1,0 +1,86 @@
+const axios = require('axios');
+const fs = require('fs');
+
+const adminurl = "http://127.0.0.1:8001";
+
+
+/**
+ * Function called from the admin cli, to get the Relay Admin API info
+ */
+let info = function () {
+    axios.get(`${adminurl}/info`).then(function(res) {
+    	console.log(res.data);
+    });
+};
+
+/**
+ * Function called from the admin cli, to get the Relay Admin API rawdump
+ * if filepath is not specified, prints the data
+ * @param {String} filepath - file path to store the file with the raw dump data
+ */
+let rawdump = function(filepath) {
+    axios.get(`${adminurl}/rawdump`).then((res) => {
+	    console.log(res.data);
+	    if(filepath) {
+	    fs.writeFile(filepath, JSON.stringify(res.data), 'utf8', function(){});
+	    } else {
+	    	console.log(res.data);
+	    }
+    });
+}
+
+/**
+ * Function called from the admin cli, to import the exported rawdump to the Relay Admin API
+ * @param {String} filepath - file path from where to get the raw dump data to import
+ */
+let rawimport = function (filepath) {
+	fs.readFile(filepath, 'utf8', function callback(err, data) {
+		console.log("a", JSON.parse(data));
+    		axios.post(`${adminurl}/rawimport`, JSON.parse(data)).then(function(res) {
+    			console.log(res.data);
+    		});
+	});
+};
+
+/**
+ * Function called from the admin cli, to get the Relay Admin API claimsdump
+ */
+let claimsdump = function () {
+    axios.get(`${adminurl}/claimsdump`).then(function(res) {
+    	console.log(res.data);
+	return;
+    });
+};
+
+/**
+ * Function called from the admin cli, to get the Relay Admin API mimc7
+ */
+let mimc7 = function (elements) {
+    axios.post(`${adminurl}/mimc7`, elements).then(function(res) {
+    	console.log(res.data);
+	return;
+    });
+};
+
+/**
+ * Function called from the admin cli, to get the Relay Admin API addGenericClaim
+ */
+let addGenericClaim= function (indexData, data) {
+	let d = {
+		indexData: indexData,
+		data: data
+	};
+    axios.post(`${adminurl}/genericClaim`, d).then(function(res) {
+    	console.log(res.data);
+	return;
+    });
+};
+
+module.exports = {
+	info,
+	rawdump,
+	rawimport,
+	claimsdump,
+	mimc7,
+	addGenericClaim,
+};

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ const Id = require('./id/id');
 const dapp = require('./auth/dapp');
 const utils = require('./utils');
 const auth = require('./auth/auth');
+const admin = require('./admin/requests');
 
 const { Auth } = auth;
 const { Dapp } = dapp;
@@ -25,4 +26,5 @@ module.exports = {
   dapp,
   Dapp,
   utils,
+  admin,
 };


### PR DESCRIPTION
admin module from node cli that performs requests to the admin internal API from the Relay

admin rawdump() and rawimport() done

implements #16 