### PR TITLE
Let if flow: begin flow integration

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,11 @@
+{
+  "presets": ["env", "flow"],
+  "plugins": [
+    [ "transform-runtime",
+      { "polyfill": false,
+        "regenerator": true
+      }
+    ],
+    "syntax-flow"
+  ]
+}

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,12 +1,17 @@
 {
-  "extends": "airbnb-base",
+  "parser": "babel-eslint",
+  "extends": [
+    "airbnb-base",
+    "plugin:flowtype/recommended"
+  ],
   "env": {
     "browser": true,
     "node": true,
     "mocha": true
   },
   "plugins": [
-    "mocha"
+    "mocha",
+    "flowtype"
   ],
   "rules": {
     "mocha/no-exclusive-tests": "error",
@@ -19,6 +24,8 @@
     "class-methods-use-this": [0],
     "no-bitwise": [0],
     "no-param-reassign": "off",
-    "no-console": [2, { "allow": ["warn", "error"] }]
+    "no-console": [2, { "allow": ["warn", "error"] }],
+    "import/prefer-default-export": [0],
+    "lines-between-class-members": [ "error", "always", { "exceptAfterSingleLine": true }]
   }
 }

--- a/.flowconfig
+++ b/.flowconfig
@@ -1,0 +1,12 @@
+[ignore]
+.*/node_modules/.*/test/.*
+
+[include]
+
+[libs]
+
+[lints]
+
+[options]
+
+[strict]

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ notes.js
 tmp
 .idea
 .vscode
+iden3js-bundle.js
+lib

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,7 @@ sudo: required
 language: node_js
 node_js:
   - "8"
-script: npm run test:unit
+script: 
+  - npm run flow check
+#  - npm run lint
+  - npm run test:unit

--- a/flow.md
+++ b/flow.md
@@ -1,0 +1,26 @@
+With yarn:
+```
+yarn add --dev babel-cli babel-preset-flow flow-bin
+```
+
+With npm:
+```
+npm install --save-dev babel-cli babel-preset-flow flow-bin babel-eslint eslint-plugin-flowtype babel-preset-env
+```
+
+Or better, install the npm dependencies from the package.json:
+```
+npm install
+```
+
+Plugin for VSCode: https://github.com/flowtype/flow-for-vscode
+
+Manually via terminal:
+```
+yarn run flow
+```
+
+To add flow to mocha tests, you need to add this line:
+```
+import { describe, it } from 'mocha';
+```

--- a/index.js
+++ b/index.js
@@ -1,3 +1,3 @@
-const iden3js = require('./src/index.js');
+const iden3js = require('./lib/index.js');
 
 module.exports = iden3js;

--- a/package.json
+++ b/package.json
@@ -7,9 +7,13 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test:unit": "rm -rf tmp && mocha --recursive 'src/**/*.test.js' --timeout 100000 ",
-    "test:int": "rm -rf tmp && mocha --timeout 20000",
-    "test:all": "rm -rf tmp && mocha --recursive --timeout 100000 npm run 'src/**/*.test.js' && mocha --timeout 100000"
+    "test:unit": "rm -rf tmp && mocha --require mock-local-storage --recursive 'lib/**/*.test.js' --timeout 100000",
+    "test:int": "rm -rf tmp && mocha --require mock-local-storage --timeout 20000",
+    "test:all": "npm run test:unit && npm run test:int",
+    "build": "babel src/ -d lib/",
+    "prepublish": "npm run build",
+    "flow": "flow",
+    "browserify": "browserify index.js --standalone iden3 > iden3js-bundle.js"
   },
   "author": "iden3.io",
   "license": "ISC",
@@ -35,11 +39,25 @@
     "web3": "1.0.0-beta.33"
   },
   "devDependencies": {
+    "babel-cli": "^6.26.0",
+    "babel-eslint": "^10.0.1",
+    "babel-plugin-syntax-flow": "^6.18.0",
+    "babel-plugin-transform-class-properties": "^6.24.1",
+    "babel-plugin-transform-runtime": "^6.23.0",
+    "babel-preset-env": "^1.7.0",
+    "babel-preset-flow": "^6.23.0",
+    "browserify": "^16.2.3",
+    "bufferutil": "^4.0.1",
     "eslint": "^5.9.0",
     "eslint-config-airbnb-base": "^13.1.0",
+    "eslint-plugin-flowtype": "^3.2.1",
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-mocha": "^5.2.0",
+    "flow-bin": "^0.92.0",
+    "flow-typed": "^2.5.1",
+    "mock-local-storage": "^1.1.8",
     "node-localstorage": "^1.3.1",
+    "utf-8-validate": "^5.0.2",
     "ws": "^5.2.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "build": "babel src/ -d lib/",
     "prepublish": "npm run build",
     "flow": "flow",
-    "browserify": "browserify index.js --standalone iden3 > iden3js-bundle.js"
+    "browserify": "browserify index.js --standalone iden3 > iden3js-bundle.js",
+    "lint": "eslint ./src"
   },
   "author": "iden3.io",
   "license": "ISC",

--- a/src/auth/dapp.js
+++ b/src/auth/dapp.js
@@ -113,7 +113,7 @@ class Dapp {
   async recv_wallet(message) {
     status(`wallet got ${message}`, true);
 
-    const [op, args] = message.split('|');
+    let [op, args] = message.split('|');
     if (op === 'call') {
       ksignaddr = '0xee602447b5a75cf4f25367f5d199b860844d10c4';
       ksignpvk = ethutil.toBuffer('0x8A85AAA2A8CE0D24F66D3EAA7F9F501F34992BACA0FF942A8EDF7ECE6B91F713');

--- a/src/key-container/local-storage-container.js
+++ b/src/key-container/local-storage-container.js
@@ -11,10 +11,10 @@ nacl.util = require('tweetnacl-util');
 
 const { secp256k1 } = ethUtil;
 
-if (typeof localStorage === 'undefined' || localStorage === null) {
-  const LocalStorage = require('node-localstorage').LocalStorage;
-  localStorage = new LocalStorage('./tmp');
-}
+// if (typeof localStorage === 'undefined' || localStorage === null) {
+//   const LocalStorage = require('node-localstorage').LocalStorage;
+//   localStorage = new LocalStorage('./tmp');
+// }
 
 class LocalStorageContainer {
   constructor(db) {

--- a/src/protocols/login.test.js
+++ b/src/protocols/login.test.js
@@ -1,12 +1,17 @@
-const chai = require('chai');
-const {expect} = chai;
+// @flow
 
-const iden3 = require('../index');
+import { describe, it } from 'mocha';
+
+const chai = require('chai');
+
+const { expect } = chai;
+
 const snarkjs = require('snarkjs');
+const iden3 = require('../index');
 const smt = require('../sparse-merkle-tree/sparse-merkle-tree');
 const Entry = require('../claim/entry/entry');
 
-const bigInt = snarkjs.bigInt;
+const { bigInt } = snarkjs;
 
 const db = new iden3.Db();
 const relayAddr = '0xe0fbce58cfaa72812103f003adce3f284fe5fc7c';
@@ -18,11 +23,11 @@ const mnemonic = 'enjoy alter satoshi squirrel special spend crop link race rall
 kc.unlock('pass');
 kc.generateMasterSeed(mnemonic);
 const mnemonicDb = kc.getMasterSeed();
-const ack = kc.generateKeySeed(mnemonicDb);
+kc.generateKeySeed(mnemonicDb);
 const { keySeed, pathKey } = kc.getKeySeed();
 const objectKeys = kc.generateKeysFromKeyPath(keySeed, pathKey);
-({ keys } = objectKeys);
-const relay = new iden3.Relay('http://127.0.0.1:8000/api/v0.1');
+const { keys } = objectKeys;
+// const relay = new iden3.Relay('http://127.0.0.1:8000/api/v0.1');
 // let id = new iden3.Id(keys[1], keys[2], keys[3], relay, relayAddr, '', undefined, 0);
 const ksign = keys[1]; // public key in hex format
 
@@ -42,11 +47,11 @@ const proofOfEthName = {
         aux: null,
         mtp0: '0001000000000000000000000000000000000000000000000000000000000001083dbb7700313075a2b8fe34b0188ff44784e3dc60987ed9277b59fad48f8199',
         mtp1: '03010000000000000000000000000000000000000000000000000000000000010fef40cc16896de64be5a0f827799555344fd3d9aade9b65d95ecfbcac3e5a73182adc955c46e6629ac74027ded0c843c7c65e8c3c4f12f77add56500f9f402e25451237d9133b0f5c1386b7b822f382cb14c5fff612a913956ef5436fb6208a',
-        root: '1b6feefde6e76c1e9d98d30fa0993a7a7b35f5b2580a757c9a57ee383dc50b96'
-      }
+        root: '1b6feefde6e76c1e9d98d30fa0993a7a7b35f5b2580a757c9a57ee383dc50b96',
+      },
     ],
-    signature: '4e0c47fe90f3438df2ed520101b214ce3f0088dafec479c997d970097119d8ba10493cf247c428b5819c8c025b9c3f5501d9e15a1f036ea54ed09ae0a754fb9700'
-  }
+    signature: '4e0c47fe90f3438df2ed520101b214ce3f0088dafec479c997d970097119d8ba10493cf247c428b5819c8c025b9c3f5501d9e15a1f036ea54ed09ae0a754fb9700',
+  },
 };
 
 const proofOfKSign = {
@@ -57,19 +62,19 @@ const proofOfKSign = {
       aux: {
         version: 0,
         era: 0,
-        ethAddr: '0x7b471a1bdbd3b8ac98f3715507449f3a8e1f3b22'
+        ethAddr: '0x7b471a1bdbd3b8ac98f3715507449f3a8e1f3b22',
       },
       mtp0: '0000000000000000000000000000000000000000000000000000000000000000',
       mtp1: '030000000000000000000000000000000000000000000000000000000000000028f8267fb21e8ce0cdd9888a6e532764eb8d52dd6c1e354157c78b7ea281ce801541a6b5aa9bf7d9be3d5cb0bcc7cacbca26242016a0feebfc19c90f2224baed',
-      root: '1d9d41171c4b621ff279e2acb84d8ab45612fef53e37225bdf67e8ad761c3922'
+      root: '1d9d41171c4b621ff279e2acb84d8ab45612fef53e37225bdf67e8ad761c3922',
     }, {
       aux: null,
       mtp0: '0000000000000000000000000000000000000000000000000000000000000000',
       mtp1: '0300000000000000000000000000000000000000000000000000000000000000182adc955c46e6629ac74027ded0c843c7c65e8c3c4f12f77add56500f9f402e25451237d9133b0f5c1386b7b822f382cb14c5fff612a913956ef5436fb6208a',
-      root: '083dbb7700313075a2b8fe34b0188ff44784e3dc60987ed9277b59fad48f8199'
-    }
+      root: '083dbb7700313075a2b8fe34b0188ff44784e3dc60987ed9277b59fad48f8199',
+    },
   ],
-  signature: '000c3f2ecd731905c8ce1e05de6a1edd09fe06611fef1cd700d3a84537bf6dc21e7b8f158f252cc583542c449b824cbf21080b9c5b46d27c036ceb32f51c2d2801'
+  signature: '000c3f2ecd731905c8ce1e05de6a1edd09fe06611fef1cd700d3a84537bf6dc21e7b8f158f252cc583542c449b824cbf21080b9c5b46d27c036ceb32f51c2d2801',
 };
 
 describe('[protocol] interns', () => {
@@ -118,7 +123,7 @@ describe('[protocol] login flow', () => {
 
     const origin = 'domain.io';
     // login backend:
-    const nonceDB = new iden3.protocols.NonceDB();
+    const nonceDB = new iden3.protocols.nonceDB.NonceDB();
     const signatureRequest = iden3.protocols.login.newRequestIdenAssert(nonceDB, origin, 2 * 60);
 
     // check that the nonce is in the nonceDB
@@ -128,22 +133,23 @@ describe('[protocol] login flow', () => {
     const unixtime = Math.round((date).getTime() / 1000);
     const expirationTime = unixtime + (3600 * 60);
     // identity wallet:
-    const signedPacket = iden3.protocols.login.signIdenAssertV01(signatureRequest, usrAddr, ethName, proofOfEthName, kc, ksign, proofOfKSign, expirationTime);
+    const signedPacket = iden3.protocols.login.signIdenAssertV01(signatureRequest, usrAddr,
+      ethName, proofOfEthName, kc, ksign, proofOfKSign, expirationTime);
 
     // login backend:
-    const nonce = iden3.protocols.login.verifySignedPacket(nonceDB, origin, signedPacket);
-    expect(nonce).to.be.not.equal(undefined);
+    const nonceVerified = iden3.protocols.login.verifySignedPacket(nonceDB, origin, signedPacket);
+    expect(nonceVerified).to.be.not.equal(undefined);
 
     // check that the nonce returned when deleting the nonce of the signedPacket, is the same
     // than the nonce of the signatureRequest
-    expect(nonce.nonce).to.be.equal(signatureRequest.body.data.challenge);
+    expect(nonceVerified.nonce.nonce).to.be.equal(signatureRequest.body.data.challenge);
 
     // nonce must not be more in the nonceDB
-    expect(nonceDB.search(nonce.nonce)).to.be.equal(undefined);
+    expect(nonceDB.search(nonceVerified.nonce)).to.be.equal(undefined);
 
-    expect(nonce.ethName + '@iden3.io').to.be.equal(ethName);
-    expect(nonce.ethAddr).to.be.equal(usrAddr);
-    
+    expect(`${nonceVerified.ethName}@iden3.io`).to.be.equal(ethName);
+    expect(nonceVerified.ethAddr).to.be.equal(usrAddr);
+
     // check that an already checked signedPacket is not more longer available to be verified
     const nonceF = iden3.protocols.login.verifySignedPacket(nonceDB, origin, signedPacket);
     expect(nonceF).to.be.equal(undefined);

--- a/src/protocols/nonceDB.js
+++ b/src/protocols/nonceDB.js
@@ -1,7 +1,22 @@
+// @flow
+
+export type NonceObj = {
+  nonce: string,
+  timestamp: number,
+  aux: any,
+};
+
+export type NonceResult = {
+    nonce: NonceObj,
+    index: number,
+};
+
 /**
 * Class representing the NonceDB
 */
-class NonceDB {
+export class NonceDB {
+  nonces: Array<NonceObj>;
+
   /**
 * Initialize NonceDB
 */
@@ -15,11 +30,11 @@ class NonceDB {
 * @param {String} nonce
 * @param {Number} timeout, in unixtime format
 */
-  _add(nonce, timeout) {
+  _add(nonce: string, timeout: number): NonceObj {
     const nonceObj = {
-      nonce: nonce,
+      nonce,
       timestamp: timeout,
-      aux: undefined
+      aux: undefined,
     };
     this.nonces.push(nonceObj);
     return nonceObj;
@@ -31,7 +46,7 @@ class NonceDB {
 * @param {String} nonce
 * @param {Number} delta, in seconds unit
 */
-  add(nonce, delta) {
+  add(nonce: string, delta: number): NonceObj {
     const date = new Date();
     const timestamp = Math.round((date).getTime() / 1000);
     const timeout = timestamp + delta;
@@ -45,7 +60,7 @@ class NonceDB {
 * @param {Object} aux
 * @param {bool}
 */
-  addAuxToNonce(nonce, aux) {
+  addAuxToNonce(nonce: string, aux: any): boolean {
     for (let i = 0; i < this.nonces.length; i++) {
       if (this.nonces[i].nonce === nonce) {
         if (this.nonces[i].aux !== undefined) {
@@ -64,13 +79,13 @@ class NonceDB {
 * @param {String} nonce
 * @returns {Object}
 */
-  search(nonce) {
+  search(nonce: string): ?NonceResult {
     this.deleteOld();
     for (let i = 0; i < this.nonces.length; i++) {
       if (this.nonces[i].nonce === nonce) {
         return {
           nonce: this.nonces[i],
-          index: i
+          index: i,
         };
       }
     }
@@ -82,9 +97,9 @@ class NonceDB {
 * @param {String} nonce
 * @returns {bool}
 */
-  searchAndDelete(nonce) {
+  searchAndDelete(nonce: string): ?NonceResult {
     const n = this.search(nonce);
-    if (n === undefined) {
+    if (n == null) {
       return undefined;
     }
     this.nonces.splice(n.index, 1);
@@ -95,9 +110,9 @@ class NonceDB {
 * Delete element in NonceDB
 * @param {String} nonce
 */
-  deleteElem(nonce) {
+  deleteElem(nonce: string) {
     const n = this.search(nonce);
-    if (n === undefined) {
+    if (n == null) {
       return;
     }
     this.nonces.splice(n.index, 1);
@@ -107,8 +122,8 @@ class NonceDB {
 * Delete nonces with timestamp older than the given
 * @param {Number} timestamp - if not specified will get current time
 */
-  deleteOld(timestamp) {
-    if (timestamp === undefined) {
+  deleteOld(timestamp: ?number) {
+    if (timestamp == null) {
       const date = new Date();
       timestamp = Math.round((date).getTime() / 1000);
     }
@@ -120,5 +135,3 @@ class NonceDB {
     }
   }
 }
-
-module.exports = NonceDB;

--- a/src/protocols/nonceDB.test.js
+++ b/src/protocols/nonceDB.test.js
@@ -1,10 +1,10 @@
 // @flow
 import { describe, it } from 'mocha';
-import { NonceDB } from './nonceDB';
+import { NonceDB, type NonceResult } from './nonceDB';
 
 const chai = require('chai');
 
-const { expect } = chai;
+const { expect, assert } = chai;
 
 // const crypto = require('crypto');
 
@@ -67,8 +67,8 @@ describe('[protocol] nonce', () => {
       param1: 1,
       param2: 2,
     })).to.be.equal(true);
-    const result = nonceDB.search('asdf0');
-    if (result == null) { return; }
+    const result = (nonceDB.search('asdf0'): any); // This is a type casting
+    expect(result).to.not.be.equal(undefined);
     expect(result.nonce.aux.param1).to.be.equal(1);
   });
   it('nonce searchAndDelete', () => {
@@ -79,9 +79,8 @@ describe('[protocol] nonce', () => {
       param1: 1,
       param2: 2,
     });
-    const result = nonceDB.searchAndDelete('asdf3');
-    // TODO: assert(result != null);
-    if (result == null) { return; }
+    const result = (nonceDB.searchAndDelete('asdf3'): any);
+    expect(result).to.not.be.equal(undefined);
     expect(result.nonce.aux.param1).to.be.equal(1);
   });
 });

--- a/src/protocols/nonceDB.test.js
+++ b/src/protocols/nonceDB.test.js
@@ -1,8 +1,12 @@
+// @flow
+import { describe, it } from 'mocha';
+import { NonceDB } from './nonceDB';
+
 const chai = require('chai');
-const {expect} = chai;
+
+const { expect } = chai;
 
 // const crypto = require('crypto');
-const NonceDB = require('./nonceDB');
 
 describe('[protocol] nonce', () => {
   it('nonce', () => {
@@ -12,7 +16,7 @@ describe('[protocol] nonce', () => {
 
     for (let i = 0; i < 10; i++) {
       // const randnonce = crypto.randomBytes(32).toString('base64');
-      const randnonce = 'asdf' + i;
+      const randnonce = `asdf${i}`;
       nonceDB.add(randnonce, 5);
     }
 
@@ -29,8 +33,8 @@ describe('[protocol] nonce', () => {
 
     for (let i = 0; i < 10; i++) {
       // const randnonce = crypto.randomBytes(32).toString('base64');
-      const randnonce = 'asdf' + i;
-      timeout++;
+      const randnonce = `asdf${i}`;
+      timeout += 1;
       nonceDB._add(randnonce, timeout);
     }
 
@@ -51,19 +55,21 @@ describe('[protocol] nonce', () => {
     expect(nonceDB.search('asdf0')).to.be.not.equal(undefined);
     expect(nonceDB.addAuxToNonce('asdf0', {
       param1: 1,
-      param2: 2
+      param2: 2,
     })).to.be.equal(true);
     // check that one aux can be added only one time in a nonce in the nonceDB
     expect(nonceDB.addAuxToNonce('asdf0', {
       param1: 1,
-      param2: 2
+      param2: 2,
     })).to.be.equal(false);
     expect(nonceDB.addAuxToNonce('asdf0', 'auxdata')).to.be.equal(false);
     expect(nonceDB.addAuxToNonce('asdf1', {
       param1: 1,
-      param2: 2
+      param2: 2,
     })).to.be.equal(true);
-    expect(nonceDB.search('asdf0').nonce.aux.param1).to.be.equal(1);
+    const result = nonceDB.search('asdf0');
+    if (result == null) { return; }
+    expect(result.nonce.aux.param1).to.be.equal(1);
   });
   it('nonce searchAndDelete', () => {
     const nonceDB = new NonceDB();
@@ -71,8 +77,11 @@ describe('[protocol] nonce', () => {
     nonceDB.add('asdf3', 1000);
     nonceDB.addAuxToNonce('asdf3', {
       param1: 1,
-      param2: 2
+      param2: 2,
     });
-    expect(nonceDB.searchAndDelete('asdf3').nonce.aux.param1).to.be.equal(1);
+    const result = nonceDB.searchAndDelete('asdf3');
+    // TODO: assert(result != null);
+    if (result == null) { return; }
+    expect(result.nonce.aux.param1).to.be.equal(1);
   });
 });

--- a/src/protocols/proofs.js
+++ b/src/protocols/proofs.js
@@ -1,3 +1,4 @@
+// @flow
 const ethUtil = require('ethereumjs-util');
 
 const utils = require('../utils');
@@ -7,30 +8,29 @@ const smt = require('../sparse-merkle-tree/sparse-merkle-tree');
 const claim = require('../claim/claim');
 const CONSTANTS = require('../constants');
 
-/** Class representing proof of a valid claim, from the claim to the top level
- * tree root, including proofs of non-existence of the revoked/next version of
- * each claim.  Includes the top level tree root key signature by the owner of
- * the top level tree. */
-class ProofClaimFull {
-  /**
-   * Create a ClaimProof
-   * @param {Signature} rootKeySig
-   * @param {Number} date
-   * @param {Leaf} leaf
-   * @param {[]ProofClaim} proofs
-   */
-  constructor(rootKeySig, date, leaf, proofs) {
-    this.signature = rootKeySig;
-    this.date = date;
-    this.leaf = leaf;
-    this.proofs = proofs;
+/**
+ * Auxiliary data required to build a set root claim
+ */
+class SetRootAux {
+  ethAddr: string;
+  ver: number;
+  era: number;
+
+  constructor(ethAddr: string, version: number, era: number) {
+    this.ethAddr = ethAddr;
+    this.ver = version;
+    this.era = era;
   }
 }
 
 /**
  * Class representing a merkle tree proof of existence of a leaf, a merkle tree
  * proof of non existence of the same leaf with the following version */
-class MtpProof {
+class ProofClaimPartial {
+  mtp0: string;
+  mtp1: string;
+  root: string;
+  aux: ?SetRootAux;
   /**
    * Create an MtpProof
    * @param {MerkleTreeProof} mtp0
@@ -38,7 +38,7 @@ class MtpProof {
    * @param {key} root
    * @param {SetRootAux|null} aux
    */
-  constructor(mtp0, mtp1, root, aux) {
+  constructor(mtp0: string, mtp1: string, root: string, aux: ?SetRootAux) {
     this.mtp0 = mtp0;
     this.mtp1 = mtp1;
     this.root = root;
@@ -46,51 +46,64 @@ class MtpProof {
   }
 }
 
-/**
- * Auxiliary data required to build a set root claim
- */
-class SetRootAux {
-  constructor(ethAddr, version, era) {
-    this.ethAddr = ethAddr;
-    this.ver = version;
-    this.era = era;
+/** Class representing proof of a valid claim, from the claim to the top level
+ * tree root, including proofs of non-existence of the revoked/next version of
+ * each claim.  Includes the top level tree root key signature by the owner of
+ * the top level tree. */
+class ProofClaim {
+  signature: string;
+  date: number;
+  leaf: string;
+  proofs: Array<ProofClaimPartial>;
+  /**
+   * Create a ClaimProof
+   * @param {Signature} rootKeySig
+   * @param {Number} date
+   * @param {Leaf} leaf
+   * @param {[]ProofClaimPartial} proofs
+   */
+  constructor(rootKeySig: string, date: number, leaf: string, proofs: Array<ProofClaimPartial>) {
+    this.signature = rootKeySig;
+    this.date = date;
+    this.leaf = leaf;
+    this.proofs = proofs;
   }
 }
 
 // TODO: Move this to claim utils
-const incClaimVersion = function incClaimVersion(cl) {
-  //let entry = new Entry();
-  //entry.fromHexadecimal(claim);
+const incClaimVersion = function incClaimVersion(cl: Entry) {
+  // let entry = new Entry();
+  // entry.fromHexadecimal(claim);
   const version = cl.elements[3].slice(20, 24).readUInt32BE(0);
   cl.elements[3].writeUInt32BE(version + 1, cl.elements[3].length - 64 / 8 - 32 / 8);
 };
 
 // TODO: Move this to merkle-tree utils
-const isMerkleTreeProofExistence = function isMerkleTreeProofExistence(proofHex) {
+const isMerkleTreeProofExistence = function isMerkleTreeProofExistence(proofHex: string): boolean {
   const proofBuff = mtHelpers.parseProof(proofHex);
   const flagNonExistence = mtHelpers.getBit(proofBuff.flagExistence, 0);
   return !flagNonExistence;
 };
 
 /**
- * Verify a ProofClaimFull from the claim to the blockchain root
- * @param{ProofClaimFull} proof
+ * Verify a ProofClaim from the claim to the blockchain root
+ * @param{ProofClaim} proof
  */
-const verifyProofClaimFull = function verifyProofClaimFull(proof, relayAddr) {
+const verifyProofClaim = function verifyProofClaim(proof: ProofClaim, relayAddr: string): boolean {
   // Verify that signature(proof.proofs[proof.proofs.length - 1].root) === proof.rootKeySig
   let rootK = proof.proofs[proof.proofs.length - 1].root;
   if (rootK.substr(0, 2) !== '0x') {
-    rootK = '0x' + rootK;
+    rootK = `0x${rootK}`;
   }
   // const date = proof.proofs[proof.proofs.length - 1].Date;
-  const date = proof.date;
+  const { date } = proof;
   const dateBytes = utils.uint64ToEthBytes(date);
   const dateHex = utils.bytesToHex(dateBytes);
   const msg = `${rootK}${dateHex.slice(2)}`;
   const msgBuffer = ethUtil.toBuffer(msg);
   const msgHash = ethUtil.hashPersonalMessage(msgBuffer);
   const msgHashHex = utils.bytesToHex(msgHash);
-  let sig = utils.hexToBytes(proof.signature);
+  const sig = utils.hexToBytes(proof.signature);
   sig[64] += 27;
   const signatureHex = utils.bytesToHex(sig);
   if (!utils.verifySignature(msgHashHex, signatureHex, relayAddr)) { // mHex, sigHex, addressHex
@@ -112,8 +125,8 @@ const verifyProofClaimFull = function verifyProofClaimFull(proof, relayAddr) {
     const mtpEx = proof.proofs[i].mtp0;
     const mtpNoEx = proof.proofs[i].mtp1;
     // WARNING: leafNoEx points to the same content of leaf, so modifying leafNoEx modifies leaf!
-    //var leafNoEx = leaf
-    //incClaimVersion(leafNoEx)
+    // var leafNoEx = leaf
+    // incClaimVersion(leafNoEx)
     rootKey = proof.proofs[i].root;
 
     if (!isMerkleTreeProofExistence(mtpEx)) {
@@ -125,7 +138,7 @@ const verifyProofClaimFull = function verifyProofClaimFull(proof, relayAddr) {
     if (isMerkleTreeProofExistence(mtpNoEx)) {
       return false;
     }
-    incClaimVersion(leaf)
+    incClaimVersion(leaf);
     if (smt.checkProof(rootKey, mtpNoEx, utils.bytesToHex(leaf.hi()), utils.bytesToHex(leaf.hv())) !== true) {
       return false;
     }
@@ -133,24 +146,25 @@ const verifyProofClaimFull = function verifyProofClaimFull(proof, relayAddr) {
     if (i === proof.proofs.length - 1) {
       break;
     }
-    const version = proof.proofs[i].aux.ver;
-    const era = proof.proofs[i].aux.era;
-    const ethAddr = proof.proofs[i].aux.ethAddr;
+    if (proof.proofs[i].aux == null) {
+      return false;
+    }
+    const { ver, era, ethAddr } = proof.proofs[i].aux;
     // leaf = new iden3.claims.SetRootKey(version, era, ethAddr, rootKey);
     leaf = new claim.Factory(CONSTANTS.CLAIMS.SET_ROOT_KEY.ID, {
-      version: version,
-      era: era,
+      ver,
+      era,
       id: ethAddr,
-      rootKey: rootKey
+      rootKey,
     }).createEntry();
   }
 
   return true;
-}
+};
 
 module.exports = {
-  verifyProofClaimFull,
-  ProofClaimFull,
-  MtpProof,
-  SetRootAux
+  verifyProofClaim,
+  ProofClaim,
+  ProofClaimPartial,
+  SetRootAux,
 };

--- a/src/protocols/protocols.js
+++ b/src/protocols/protocols.js
@@ -1,9 +1,10 @@
-const NonceDB = require('./nonceDB');
+// @flow
+const nonceDB = require('./nonceDB');
 const login = require('./login');
 const proofs = require('./proofs');
 
 module.exports = {
-  NonceDB,
+  nonceDB,
   login,
-  verifyProofClaimFull: proofs.verifyProofClaimFull
+  verifyProofClaimFull: proofs.verifyProofClaim,
 };

--- a/test/protocols-login.test.js
+++ b/test/protocols-login.test.js
@@ -50,7 +50,7 @@ describe('[protocol] login', () => {
 
   it('newRequestIdenAssert', () => {
     const origin = 'domain.io';
-    const nonceDB = new iden3.protocols.NonceDB();
+    const nonceDB = new iden3.protocols.nonceDB.NonceDB();
     const signatureRequest = iden3.protocols.login.newRequestIdenAssert(nonceDB, origin, 2 * 60);
 
     const date = new Date();


### PR DESCRIPTION
This commit adds flow support to iden3js.

This requires building with babel: `npm run build`, which will transpile the contents of `src/` to javascript into `lib/`.  Using babel also allows using ES6.

Before merging, we need to verify that the browsified version still works correctly.

Read flow.md for details on how to use flow. 