### PR TITLE
Make it work with Node 10

### DIFF
--- a/src/claim/claim.js
+++ b/src/claim/claim.js
@@ -20,7 +20,7 @@ const i3utils = require('../utils');
 // eslint-disable-next-line max-len
 function newClaimFromEntry(entry: Entry): void | Basic | AuthorizeKSign | SetRootKey | AssignName | AuthorizeKSignSecp256k1 | LinkObjectIdentity {
   // Decode claim type from Entry class
-  const claimType = i3utils.bufferToBigInt(entry.elements[3].slice(24, 32)).value;
+  const claimType = Number(i3utils.bufferToBigInt(entry.elements[3].slice(24, 32)));
   // Parse elements and return the proper claim structure
   switch (claimType) {
     case CONSTANTS.CLAIMS.BASIC.TYPE:
@@ -36,7 +36,7 @@ function newClaimFromEntry(entry: Entry): void | Basic | AuthorizeKSign | SetRoo
     case CONSTANTS.CLAIMS.LINK_OBJECT_IDENTITY.TYPE:
       return LinkObjectIdentity.newFromEntry(entry);
     default:
-      return undefined;
+      throw new Error(`Unknown claim type ${claimType}`);
   }
 }
 

--- a/src/protocols/login.test.js
+++ b/src/protocols/login.test.js
@@ -96,7 +96,7 @@ describe('[protocol]', () => {
   it('test bigint', () => {
     // check that node version supports shiftLeft on bigInt
     bigInt(8).toString();
-    bigInt(8).shiftLeft(2);
+    bigInt(8).shl(2);
   });
 
   it('test check proof', () => {

--- a/src/sparse-merkle-tree/sparse-merkle-tree-utils.js
+++ b/src/sparse-merkle-tree/sparse-merkle-tree-utils.js
@@ -1,5 +1,7 @@
 import { Entry } from '../claim/entry/entry';
 
+const { bigInt } = require('snarkjs');
+
 const utils = require('../utils');
 
 /**
@@ -31,7 +33,21 @@ export function getBit(byte, pos) {
 * @returns {Array(Uint8)} - Array of bits determining leaf position
 */
 export function getIndexArray(index) {
-  return index.toArray(2).value.reverse();
+  let k = bigInt(index);
+  const res = [];
+
+  while (!k.isZero()) {
+    if (k.isOdd()) {
+      res.push(1);
+    } else {
+      res.push(0);
+    }
+    k = k.shr(1);
+  }
+
+  while (res.length < 256) res.push(false);
+
+  return res;
 }
 
 /**


### PR DESCRIPTION
This commit makes iden3js work with Node 10 (the changes are related to BigInts and Buffers).  It probably breaks compatibility with Node 8, but we need to move on!