### PR TITLE
rename function to add big-endian info

### DIFF
--- a/src/claim/assign-name/assign-name.js
+++ b/src/claim/assign-name/assign-name.js
@@ -28,7 +28,7 @@ export class AssignName {
    * Claim type is used to define this concrete claim. This parameter takes 8 bytes.
    */
   constructor(version: Buffer, hashName: Buffer, id: Buffer) {
-    this.claimType = utils.bigIntToBuffer(bigInt(CONSTANTS.CLAIMS.ASSIGN_NAME.TYPE)).slice(24, 32);
+    this.claimType = utils.bigIntToBufferBE(bigInt(CONSTANTS.CLAIMS.ASSIGN_NAME.TYPE)).slice(24, 32);
     this.version = version;
     this.hashName = hashName;
     this.id = id;

--- a/src/claim/authorize-ksign-babyjub/authorize-ksign-babyjub.js
+++ b/src/claim/authorize-ksign-babyjub/authorize-ksign-babyjub.js
@@ -29,7 +29,7 @@ export class AuthorizeKSignBabyJub {
    * Claim type is used to define this concrete claim. This parameter takes 8 bytes.
    */
   constructor(version: Buffer, sign: Buffer, ay: Buffer) {
-    this.claimType = utils.bigIntToBuffer(bigInt(CONSTANTS.CLAIMS.AUTHORIZE_KSIGN_BABYJUB.TYPE)).slice(24, 32);
+    this.claimType = utils.bigIntToBufferBE(bigInt(CONSTANTS.CLAIMS.AUTHORIZE_KSIGN_BABYJUB.TYPE)).slice(24, 32);
     this.version = version;
     this.sign = sign;
     this.ay = ay;

--- a/src/claim/authorize-ksign-secp256k1/authorize-ksign-secp256k1.js
+++ b/src/claim/authorize-ksign-secp256k1/authorize-ksign-secp256k1.js
@@ -28,7 +28,7 @@ export class AuthorizeKSignSecp256k1 {
    * Claim type is used to define this concrete claim. This parameter takes 8 bytes.
    */
   constructor(version: Buffer, pubKeyCompressed: Buffer) {
-    this.claimType = utils.bigIntToBuffer(bigInt(CONSTANTS.CLAIMS.AUTHORIZE_KSIGN_SECP256K1.TYPE)).slice(24, 32);
+    this.claimType = utils.bigIntToBufferBE(bigInt(CONSTANTS.CLAIMS.AUTHORIZE_KSIGN_SECP256K1.TYPE)).slice(24, 32);
     this.version = version;
     this.pubKeyCompressed = pubKeyCompressed;
   }

--- a/src/claim/basic/basic.js
+++ b/src/claim/basic/basic.js
@@ -29,7 +29,7 @@ export class Basic {
    * Claim type is used to define this concrete claim. This parameter takes 8 bytes.
    */
   constructor(version: Buffer, index: Buffer, extraData: Buffer) {
-    this.claimType = utils.bigIntToBuffer(bigInt(CONSTANTS.CLAIMS.BASIC.TYPE)).slice(24, 32);
+    this.claimType = utils.bigIntToBufferBE(bigInt(CONSTANTS.CLAIMS.BASIC.TYPE)).slice(24, 32);
     this.version = version;
     this.index = index;
     this.extraData = extraData;

--- a/src/claim/claim.js
+++ b/src/claim/claim.js
@@ -20,7 +20,7 @@ const i3utils = require('../utils');
 // eslint-disable-next-line max-len
 function newClaimFromEntry(entry: Entry): void | Basic | AuthorizeKSignBabyJub | SetRootKey | AssignName | AuthorizeKSignSecp256k1 | LinkObjectIdentity {
   // Decode claim type from Entry class
-  const claimType = Number(i3utils.bufferToBigInt(entry.elements[3].slice(24, 32)));
+  const claimType = Number(i3utils.bufferToBigIntBE(entry.elements[3].slice(24, 32)));
   // Parse elements and return the proper claim structure
   switch (claimType) {
     case CONSTANTS.CLAIMS.BASIC.TYPE:

--- a/src/claim/entry/entry.js
+++ b/src/claim/entry/entry.js
@@ -1,5 +1,5 @@
 // @flow
-import { getArrayBigIntFromBuffArray, bigIntToBuffer } from '../../utils';
+import { getArrayBigIntFromBuffArrayBE, bigIntToBufferBE } from '../../utils';
 
 const utils = require('../../utils');
 const mimc7 = require('../../sparse-merkle-tree/mimc7');
@@ -46,8 +46,8 @@ export class Entry {
    */
   hi(): Buffer {
     const hashArray = [this.elements[2], this.elements[3]];
-    const hashKey = mimc7.multiHash(getArrayBigIntFromBuffArray(hashArray));
-    return bigIntToBuffer(hashKey);
+    const hashKey = mimc7.multiHash(getArrayBigIntFromBuffArrayBE(hashArray));
+    return bigIntToBufferBE(hashKey);
   }
 
   /**
@@ -57,8 +57,8 @@ export class Entry {
    */
   hv(): Buffer {
     const hashArray = [this.elements[0], this.elements[1]];
-    const hashKey = mimc7.multiHash(getArrayBigIntFromBuffArray(hashArray));
-    return bigIntToBuffer(hashKey);
+    const hashKey = mimc7.multiHash(getArrayBigIntFromBuffArrayBE(hashArray));
+    return bigIntToBufferBE(hashKey);
   }
 
   /**

--- a/src/claim/link-object-identity/link-object-identity.js
+++ b/src/claim/link-object-identity/link-object-identity.js
@@ -36,7 +36,7 @@ export class LinkObjectIdentity {
    */
   constructor(version: Buffer, objectType: Buffer, objectIndex: Buffer,
     idAddr: Buffer, objectHash: Buffer, auxData: Buffer) {
-    this.claimType = utils.bigIntToBuffer(bigInt(CONSTANTS.CLAIMS.LINK_OBJECT_IDENTITY.TYPE)).slice(24, 32);
+    this.claimType = utils.bigIntToBufferBE(bigInt(CONSTANTS.CLAIMS.LINK_OBJECT_IDENTITY.TYPE)).slice(24, 32);
     this.version = version;
     this.objectType = objectType;
     this.objectIndex = objectIndex;

--- a/src/claim/set-root-key/set-root-key.js
+++ b/src/claim/set-root-key/set-root-key.js
@@ -29,7 +29,7 @@ export class SetRootKey {
    * Claim type is used to define this concrete claim. This parameter takes 8 bytes.
    */
   constructor(version: Buffer, era: Buffer, id: Buffer, rootKey: Buffer) {
-    this.claimType = utils.bigIntToBuffer(bigInt(CONSTANTS.CLAIMS.SET_ROOT_KEY.TYPE)).slice(24, 32);
+    this.claimType = utils.bigIntToBufferBE(bigInt(CONSTANTS.CLAIMS.SET_ROOT_KEY.TYPE)).slice(24, 32);
     this.version = version;
     this.era = era;
     this.id = id;

--- a/src/crypto/babyjub-utils.js
+++ b/src/crypto/babyjub-utils.js
@@ -17,7 +17,7 @@ const baseBabyJub = babyJub.Base8;
  * @returns {Buffer} - Public key compressed
  */
 function compressPoint(pubKeyX: Buffer, pubKeyY: Buffer): Buffer {
-  const pubKeyXBigInt = utils.bufferToBigInt(pubKeyX);
+  const pubKeyXBigInt = utils.bufferToBigIntBE(pubKeyX);
   if (pubKeyXBigInt.greater(babyJub.p.shr(1))) {
     pubKeyY[0] |= 0x80;
   }
@@ -75,8 +75,8 @@ function privToPub(privKey: Buffer, compress: boolean): Buffer {
   }
   const scalar = privToScalar(privKey);
   const pubKey = babyJub.mulPointEscalar(baseBabyJub, scalar);
-  const pubKeyX = utils.bigIntToBuffer(pubKey[0]);
-  const pubKeyY = utils.bigIntToBuffer(pubKey[1]);
+  const pubKeyX = utils.bigIntToBufferBE(pubKey[0]);
+  const pubKeyY = utils.bigIntToBufferBE(pubKey[1]);
   if (!babyJub.inSubgroup(pubKey)) {
     throw new Error('Point generated not in babyjub subgroup');
   }

--- a/src/id/id-utils.js
+++ b/src/id/id-utils.js
@@ -32,7 +32,7 @@ function calculateIdGenesis(kopComp, krecComp, krevComp) {
   const claims = generateInitialClaimsAuthorizeKSign(kopComp, krecComp, krevComp);
 
   for (let i = 0; i < claims.length; i++) {
-    const c = utils.getArrayBigIntFromBuffArray(claims[i].toEntry().elements);
+    const c = utils.getArrayBigIntFromBuffArrayBE(claims[i].toEntry().elements);
     mt.addClaim(c);
   }
   const h = utils.hashBytes(mt.root);

--- a/src/protocols/login.test.js
+++ b/src/protocols/login.test.js
@@ -114,9 +114,9 @@ describe('[protocol]', () => {
     + '0000000000000000000000000000000000000000000000010000000000000003';
     // Add leaf to sparse merkle tree
     const entry = Entry.newFromHex(leaf);
-    mt.addClaim(iden3.utils.getArrayBigIntFromBuffArray(entry.elements));
+    mt.addClaim(iden3.utils.getArrayBigIntFromBuffArrayBE(entry.elements));
     // generate proof
-    const proofBuff = mt.generateProof(iden3.utils.getArrayBigIntFromBuffArray([entry.elements[2], entry.elements[3]]));
+    const proofBuff = mt.generateProof(iden3.utils.getArrayBigIntFromBuffArrayBE([entry.elements[2], entry.elements[3]]));
     const proof = iden3.utils.bytesToHex(proofBuff);
     const root = iden3.utils.bytesToHex(mt.root);
     const verified = smt.checkProof(root, proof, iden3.utils.bytesToHex(entry.hi()), iden3.utils.bytesToHex(entry.hv()));

--- a/src/sparse-merkle-tree/sparse-merkle-tree-utils.js
+++ b/src/sparse-merkle-tree/sparse-merkle-tree-utils.js
@@ -102,7 +102,7 @@ export function genProofStruct(buffHex) {
 export function importClaimsDump(mt, claimsDump) {
   for (let i = 0; i < claimsDump.length; i++) {
     const e = Entry.newFromHex(claimsDump[i]);
-    const t = utils.getArrayBigIntFromBuffArray(e.elements);
+    const t = utils.getArrayBigIntFromBuffArrayBE(e.elements);
     mt.addClaim(t);
   }
 }

--- a/src/sparse-merkle-tree/sparse-merkle-tree.js
+++ b/src/sparse-merkle-tree/sparse-merkle-tree.js
@@ -45,7 +45,7 @@ function setNodeValue(db, key, value, prefix) {
 function getHashFinalNode(hi, hv) {
   const hashArray = [hi, hv];
   const hashKey = mimc7.multiHash(hashArray, bigInt(1));
-  return utils.bigIntToBuffer(hashKey);
+  return utils.bigIntToBufferBE(hashKey);
 }
 
 /**
@@ -108,14 +108,14 @@ class SparseMerkleTree {
 
     if (nodeValue === emptyNodeValue) {
       let nextHash = getHashFinalNode(hi, hv);
-      setNodeValue(this.db, nextHash, utils.getArrayBuffFromArrayBigInt(currentClaim), this.prefix);
+      setNodeValue(this.db, nextHash, utils.getArrayBuffFromArrayBigIntBE(currentClaim), this.prefix);
       let concat = 0;
       const level = arraySiblings.length - 1;
       for (let i = level; i >= 0; i--) {
         const bitLeaf = (i > (hiBinay.length - 1)) ? 0 : hiBinay[i];
         const siblingTmp = arraySiblings[i];
         concat = bitLeaf ? [siblingTmp, nextHash] : [nextHash, siblingTmp];
-        nextHash = utils.bigIntToBuffer(mimc7.multiHash(utils.getArrayBigIntFromBuffArray(concat)));
+        nextHash = utils.bigIntToBufferBE(mimc7.multiHash(utils.getArrayBigIntFromBuffArrayBE(concat)));
         setNodeValue(this.db, nextHash, concat, this.prefix);
       }
       this.root = nextHash;
@@ -125,7 +125,7 @@ class SparseMerkleTree {
     let lvlCounter = 0;
     if (nodeValue.length === 4) {
       // get current node value and its hIndex
-      const totalTmp = utils.getArrayBigIntFromBuffArray(nodeValue);
+      const totalTmp = utils.getArrayBigIntFromBuffArrayBE(nodeValue);
       let hiTmp = totalTmp.slice(2);
       hiTmp = helpers.getIndexArray(mimc7.multiHash(hiTmp));
       // compare position index until find a split
@@ -148,7 +148,7 @@ class SparseMerkleTree {
       arraySiblings.push(key);
       // Write current branch with new claim added
       const newHash = getHashFinalNode(hi, hv);
-      setNodeValue(this.db, newHash, utils.getArrayBuffFromArrayBigInt(currentClaim), this.prefix);
+      setNodeValue(this.db, newHash, utils.getArrayBuffFromArrayBigIntBE(currentClaim), this.prefix);
       // Recalculate nodes until the root
       let concat = 0;
       const level = arraySiblings.length - 1;
@@ -157,7 +157,7 @@ class SparseMerkleTree {
         const bitLeaf = (i > (hiBinay.length - 1)) ? 0 : hiBinay[i];
         const siblingTmp = arraySiblings[i];
         concat = bitLeaf ? [siblingTmp, nextHash] : [nextHash, siblingTmp];
-        nextHash = utils.bigIntToBuffer(mimc7.multiHash(utils.getArrayBigIntFromBuffArray(concat)));
+        nextHash = utils.bigIntToBufferBE(mimc7.multiHash(utils.getArrayBigIntFromBuffArrayBE(concat)));
         setNodeValue(this.db, nextHash, concat, this.prefix);
       }
       this.root = nextHash;
@@ -182,7 +182,7 @@ class SparseMerkleTree {
       nodeValue = getNodeValue(this.db, key, this.prefix);
       claimIndex += 1;
     }
-    return utils.getArrayBigIntFromBuffArray(nodeValue);
+    return utils.getArrayBigIntFromBuffArrayBE(nodeValue);
   }
 
   /**
@@ -223,7 +223,7 @@ class SparseMerkleTree {
       // set exist to 0
       exist = false;
       // get current node value and its hIndex
-      totalTmp = utils.getArrayBigIntFromBuffArray(nodeValue);
+      totalTmp = utils.getArrayBigIntFromBuffArrayBE(nodeValue);
       let hiTmp = totalTmp.slice(2);
       hiTmp = helpers.getIndexArray(mimc7.multiHash(hiTmp));
       // Check input index and node index
@@ -255,8 +255,8 @@ class SparseMerkleTree {
     }
     if (checkIndex) {
       const hashes = getHiHv(totalTmp);
-      const hiFinal = utils.bigIntToBuffer(hashes[0]);
-      const hvFinal = utils.bigIntToBuffer(hashes[1]);
+      const hiFinal = utils.bigIntToBufferBE(hashes[0]);
+      const hvFinal = utils.bigIntToBufferBE(hashes[1]);
       buffTmp = Buffer.concat([buffTmp, hiFinal, hvFinal]);
     }
     return buffTmp;
@@ -274,8 +274,8 @@ class SparseMerkleTree {
 function checkProof(rootHex, proofHex, hiHex, hvHex) {
   const root = utils.hexToBytes(rootHex);
   const proofBuff = helpers.parseProof(proofHex);
-  const hi = utils.bufferToBigInt(utils.hexToBytes(hiHex));
-  const hv = utils.bufferToBigInt(utils.hexToBytes(hvHex));
+  const hi = utils.bufferToBigIntBE(utils.hexToBytes(hiHex));
+  const hv = utils.bufferToBigIntBE(utils.hexToBytes(hvHex));
   const hvBuff = getHashFinalNode(hi, hv);
   const hiBinay = helpers.getIndexArray(hi);
   const { siblings } = proofBuff;
@@ -288,8 +288,8 @@ function checkProof(rootHex, proofHex, hiHex, hvHex) {
   let pos = 0;
   let newHash = emptyNodeValue;
   if (flagNonExistence && flagNonDiff) {
-    const hiTmp = utils.bufferToBigInt(proofBuff.metaData.slice(0, 32));
-    const hvTmp = utils.bufferToBigInt(proofBuff.metaData.slice(32, proofBuff.metaData.length));
+    const hiTmp = utils.bufferToBigIntBE(proofBuff.metaData.slice(0, 32));
+    const hvTmp = utils.bufferToBigIntBE(proofBuff.metaData.slice(32, proofBuff.metaData.length));
     const hiTmpBinary = helpers.getIndexArray(hiTmp);
     while (!exist && !((pos > hiBinay.length - 1) && (pos > hiTmpBinary.length - 1))) {
       const bitLeaf = (pos > (hiBinay.length - 1)) ? 0 : hiBinay[pos];
@@ -323,7 +323,7 @@ function checkProof(rootHex, proofHex, hiHex, hvHex) {
   for (let i = arrayFullSiblings.length - 1; i >= 0; i--) {
     const siblingTmp = arrayFullSiblings[i];
     concat = hiBinay[i] ? [siblingTmp, nextHash] : [nextHash, siblingTmp];
-    nextHash = utils.bigIntToBuffer(mimc7.multiHash(utils.getArrayBigIntFromBuffArray(concat)));
+    nextHash = utils.bigIntToBufferBE(mimc7.multiHash(utils.getArrayBigIntFromBuffArrayBE(concat)));
   }
   return Buffer.compare(nextHash, root) === 0;
 }

--- a/src/sparse-merkle-tree/sparse-merkle-tree.test.js
+++ b/src/sparse-merkle-tree/sparse-merkle-tree.test.js
@@ -21,10 +21,10 @@ describe('[sparse-merkle-tree] Mimc7 hash function', () => {
   it('hash array 2 bigInts', () => {
     const claim = [bigInt(12), bigInt(45), bigInt(78), bigInt(41)];
     const hi = mimc7.multiHash(claim.slice(2));
-    const hiHex = iden3.utils.bytesToHex(iden3.utils.bigIntToBuffer(hi));
+    const hiHex = iden3.utils.bytesToHex(iden3.utils.bigIntToBufferBE(hi));
     expect(hiHex).to.be.equal('0x067f3202335ea256ae6e6aadcd2d5f7f4b06a00b2d1e0de903980d5ab552dc70');
     const hv = mimc7.multiHash(claim.slice(0, 2));
-    const hvHex = iden3.utils.bytesToHex(iden3.utils.bigIntToBuffer(hv));
+    const hvHex = iden3.utils.bytesToHex(iden3.utils.bigIntToBufferBE(hv));
     expect(hvHex).to.be.equal('0x15ff7fe9793346a17c3150804bcb36d161c8662b110c50f55ccb7113948d8879');
   });
 });
@@ -33,7 +33,7 @@ describe('[sparse-merkle-tree] Mimc7 hash function', () => {
   it('hash array 4 bigInts', () => {
     const claim = [bigInt(12), bigInt(45), bigInt(78), bigInt(41)];
     const hi = mimc7.multiHash(claim);
-    const hiHex = iden3.utils.bytesToHex(iden3.utils.bigIntToBuffer(hi));
+    const hiHex = iden3.utils.bytesToHex(iden3.utils.bigIntToBufferBE(hi));
     expect(hiHex).to.be.equal('0x284bc1f34f335933a23a433b6ff3ee179d682cd5e5e2fcdd2d964afa85104beb');
   });
 });
@@ -204,8 +204,8 @@ describe('[sparse-merkle-tree] Verify proof', () => {
     const proof = mt.generateProof(proofClaim.slice(2));
 
     const hashes = iden3.sparseMerkleTree.getHiHv(proofClaim);
-    const hiHex = iden3.utils.bytesToHex(iden3.utils.bigIntToBuffer(hashes[0]));
-    const hvHex = iden3.utils.bytesToHex(iden3.utils.bigIntToBuffer(hashes[1]));
+    const hiHex = iden3.utils.bytesToHex(iden3.utils.bigIntToBufferBE(hashes[0]));
+    const hvHex = iden3.utils.bytesToHex(iden3.utils.bigIntToBufferBE(hashes[1]));
     const rootHex = iden3.utils.bytesToHex(mt.root);
     const proofHex = iden3.utils.bytesToHex(proof);
     expect(proofHex).to.be.equal('0x0007000000000000000000000000000000000000000000000000000000000043'
@@ -225,8 +225,8 @@ describe('[sparse-merkle-tree] Verify proof', () => {
     const proof = mt.generateProof(proofClaim.slice(2));
 
     const hashes = iden3.sparseMerkleTree.getHiHv(proofClaim);
-    const hiHex = iden3.utils.bytesToHex(iden3.utils.bigIntToBuffer(hashes[0]));
-    const hvHex = iden3.utils.bytesToHex(iden3.utils.bigIntToBuffer(hashes[1]));
+    const hiHex = iden3.utils.bytesToHex(iden3.utils.bigIntToBufferBE(hashes[0]));
+    const hvHex = iden3.utils.bytesToHex(iden3.utils.bigIntToBufferBE(hashes[1]));
     const rootHex = iden3.utils.bytesToHex(mt.root);
     const proofHex = iden3.utils.bytesToHex(proof);
     expect(proofHex).to.be.equal('0x0103000000000000000000000000000000000000000000000000000000000007'
@@ -247,8 +247,8 @@ describe('[sparse-merkle-tree] Verify proof', () => {
     const proof = mt.generateProof(proofClaim.slice(2));
 
     const hashes = iden3.sparseMerkleTree.getHiHv(proofClaim);
-    const hiHex = iden3.utils.bytesToHex(iden3.utils.bigIntToBuffer(hashes[0]));
-    const hvHex = iden3.utils.bytesToHex(iden3.utils.bigIntToBuffer(hashes[1]));
+    const hiHex = iden3.utils.bytesToHex(iden3.utils.bigIntToBufferBE(hashes[0]));
+    const hvHex = iden3.utils.bytesToHex(iden3.utils.bigIntToBufferBE(hashes[1]));
     const rootHex = iden3.utils.bytesToHex(mt.root);
     const proofHex = iden3.utils.bytesToHex(proof);
     expect(proofHex).to.be.equal('0x0307000000000000000000000000000000000000000000000000000000000043'
@@ -278,8 +278,8 @@ describe('[sparse-merkle-tree] Verify trick proofs', () => {
     // Verify proof with node mismatch between generated proof and  node used for verification
     const proofClaimFalse = [bigInt(0), bigInt(5), bigInt(0), bigInt(5)];
     const hashes = iden3.sparseMerkleTree.getHiHv(proofClaimFalse);
-    const hiHex = iden3.utils.bytesToHex(iden3.utils.bigIntToBuffer(hashes[0]));
-    const hvHex = iden3.utils.bytesToHex(iden3.utils.bigIntToBuffer(hashes[1]));
+    const hiHex = iden3.utils.bytesToHex(iden3.utils.bigIntToBufferBE(hashes[0]));
+    const hvHex = iden3.utils.bytesToHex(iden3.utils.bigIntToBufferBE(hashes[1]));
     const check = iden3.sparseMerkleTree.checkProof(rootHex, proofHex, hiHex, hvHex);
     expect(check).to.be.equal(false);
   });
@@ -298,9 +298,9 @@ describe('[sparse-merkle-tree] Verify trick proofs', () => {
     // and adding node metadata as auxiliary node
     objectProof.flagExistence = true;
     const hashes = iden3.sparseMerkleTree.getHiHv(proofClaim);
-    const hiHex = iden3.utils.bytesToHex(iden3.utils.bigIntToBuffer(hashes[0]));
-    const hvHex = iden3.utils.bytesToHex(iden3.utils.bigIntToBuffer(hashes[1]));
-    const hashesBuff = Buffer.concat(iden3.utils.getArrayBuffFromArrayBigInt(hashes));
+    const hiHex = iden3.utils.bytesToHex(iden3.utils.bigIntToBufferBE(hashes[0]));
+    const hvHex = iden3.utils.bytesToHex(iden3.utils.bigIntToBufferBE(hashes[1]));
+    const hashesBuff = Buffer.concat(iden3.utils.getArrayBuffFromArrayBigIntBE(hashes));
     objectProof.metaData = hashesBuff;
     const check = iden3.sparseMerkleTree.checkProof(rootHex, proofHex, hiHex, hvHex);
     expect(check).to.be.equal(false);
@@ -321,8 +321,8 @@ describe('[sparse-merkle-tree] Add Claim Repeated', () => {
     expect(iden3.utils.bytesToHex(proof)).to.be.equal('0x0000000000000000000000000000000000000000000000000000000000000000');
 
     const hashes = iden3.sparseMerkleTree.getHiHv(claim);
-    const hiHex = iden3.utils.bytesToHex(iden3.utils.bigIntToBuffer(hashes[0]));
-    const hvHex = iden3.utils.bytesToHex(iden3.utils.bigIntToBuffer(hashes[1]));
+    const hiHex = iden3.utils.bytesToHex(iden3.utils.bigIntToBufferBE(hashes[0]));
+    const hvHex = iden3.utils.bytesToHex(iden3.utils.bigIntToBufferBE(hashes[1]));
     const rootHex = iden3.utils.bytesToHex(mt.root);
     const proofHex = iden3.utils.bytesToHex(proof);
     const check = iden3.sparseMerkleTree.checkProof(rootHex, proofHex, hiHex, hvHex);

--- a/src/utils.js
+++ b/src/utils.js
@@ -206,11 +206,11 @@ function pow(data: any, difficulty: number): any {
 
 
 /**
-* Allocates a new Buffer from a bigInt number
+* Allocates a new Buffer from a bigInt number in big-endian format
 * @param {bigInt} number - bigInt number
 * @returns {Buffer} - Decoded Buffer
 */
-function bigIntToBuffer(number: bigInt): Buffer {
+function bigIntToBufferBE(number: bigInt): Buffer {
   const buff = Buffer.alloc(32);
   let pos = buff.length - 1;
   while (!number.isZero()) {
@@ -222,11 +222,11 @@ function bigIntToBuffer(number: bigInt): Buffer {
 }
 
 /**
-* Allocates a new bigInt from a buffer
+* Allocates a new bigInt from a buffer in big-endian format
 * @param {Buffer} buff - Buffer to convert
 * @returns {bigInt} - Decoded bigInt
 */
-function bufferToBigInt(buff: Buffer): bigInt {
+function bufferToBigIntBE(buff: Buffer): bigInt {
   let number = bigInt(0);
   let pos = buff.length - 1;
   while (pos >= 0) {
@@ -265,26 +265,28 @@ function bufferToBuffArray(buff: Buffer): Array<Buffer> {
 
 /**
 * Gets an array of buffers from bigInt array
+* Each buffer is in big-endian format
 * @param {Array(bigInt)} arrayBigInt - Hash index of the leaf
 * @returns {Array(Buffer)} - Array of decoded buffers
 */
-function getArrayBuffFromArrayBigInt(arrayBigInt: Array<bigInt>): Array<Buffer> {
+function getArrayBuffFromArrayBigIntBE(arrayBigInt: Array<bigInt>): Array<Buffer> {
   const arrayBuff = [];
   for (let i = 0; i < arrayBigInt.length; i++) {
-    arrayBuff.push(bigIntToBuffer(arrayBigInt[i]));
+    arrayBuff.push(bigIntToBufferBE(arrayBigInt[i]));
   }
   return arrayBuff;
 }
 
 /**
 * Gets an array of bigInt from buffer array
+* Each buffer is in big-endian format
 * @param {Array(Buffer)} arrayBuff - Array of buffer to decode
 * @returns {Array(bigInt)} - Array of bigInt decoded
 */
-function getArrayBigIntFromBuffArray(arrayBuff: Array<Buffer>): Array<bigInt> {
+function getArrayBigIntFromBuffArrayBE(arrayBuff: Array<Buffer>): Array<bigInt> {
   const arrayBigInt = [];
   for (let i = 0; i < arrayBuff.length; i++) {
-    arrayBigInt.push(bufferToBigInt(arrayBuff[i]));
+    arrayBigInt.push(bufferToBigIntBE(arrayBuff[i]));
   }
   return arrayBigInt;
 }
@@ -321,11 +323,11 @@ module.exports = {
   ethBytesToUint64,
   bytesToBase64,
   base64ToBytes,
-  bigIntToBuffer,
-  bufferToBigInt,
+  bigIntToBufferBE,
+  bufferToBigIntBE,
   buffArrayToBuffer,
   bufferToBuffArray,
-  getArrayBuffFromArrayBigInt,
-  getArrayBigIntFromBuffArray,
+  getArrayBuffFromArrayBigIntBE,
+  getArrayBigIntFromBuffArrayBE,
   swapEndianness,
 };


### PR DESCRIPTION
- rename `bigIntToBuffer` to `bigIntToBufferBE`
- rename `bufferToBigInt` to `bufferToBigIntBE`
- rename `getArrayBuffFromArrayBigInt` to `getArrayBuffFromArrayBigIntBE`
- rename `getArrayBigIntFromBuffArray` to `getArrayBigIntFromBuffArrayBE`

In order to add information about endianness used (big-endian in our case)