### PR TITLE
reorganize claim utils

### DIFF
--- a/src/claim/claim-assign-name.js
+++ b/src/claim/claim-assign-name.js
@@ -2,7 +2,7 @@
 import { Entry } from './entry';
 
 const bs58 = require('bs58');
-const claimUtils = require('./claim');
+const claimUtils = require('./claim-utils');
 
 /**
  * Class representing an assign name claim

--- a/src/claim/claim-authorize-eth-key.js
+++ b/src/claim/claim-authorize-eth-key.js
@@ -2,7 +2,7 @@
 import { Entry } from './entry';
 
 const utils = require('../utils');
-const claimUtils = require('./claim');
+const claimUtils = require('./claim-utils');
 
 /**
  * Ethereum key Types

--- a/src/claim/claim-authorize-ksign-babyjub.js
+++ b/src/claim/claim-authorize-ksign-babyjub.js
@@ -2,7 +2,7 @@
 import { Entry } from './entry';
 
 const utils = require('../utils');
-const claimUtils = require('./claim');
+const claimUtils = require('./claim-utils');
 
 /**
  * Class representing an authorized Ksign claim with babyjub curve

--- a/src/claim/claim-authorize-ksign-secp256k1.js
+++ b/src/claim/claim-authorize-ksign-secp256k1.js
@@ -2,7 +2,7 @@
 import { Entry } from './entry';
 
 const utils = require('../utils');
-const claimUtils = require('./claim');
+const claimUtils = require('./claim-utils');
 
 /**
  * Class representing an authorized Ksign claim with elliptic curve as secp256k1

--- a/src/claim/claim-basic.js
+++ b/src/claim/claim-basic.js
@@ -1,7 +1,7 @@
 // @flow
 import { Entry } from './entry';
 
-const claimUtils = require('./claim');
+const claimUtils = require('./claim-utils');
 
 /**
  * Class representing a basic claim

--- a/src/claim/claim-link-object-identity.js
+++ b/src/claim/claim-link-object-identity.js
@@ -2,7 +2,7 @@
 import { Entry } from './entry';
 
 const bs58 = require('bs58');
-const claimUtils = require('./claim');
+const claimUtils = require('./claim-utils');
 
 export const TYPE_OBJECT = {
   passport: 0,

--- a/src/claim/claim-set-root-key.js
+++ b/src/claim/claim-set-root-key.js
@@ -2,7 +2,7 @@
 import { Entry } from './entry';
 
 const bs58 = require('bs58');
-const claimUtils = require('./claim');
+const claimUtils = require('./claim-utils');
 
 /**
  * Class representing a set root key claim

--- a/src/claim/claim-utils.js
+++ b/src/claim/claim-utils.js
@@ -1,0 +1,168 @@
+// @flow
+import { Entry } from './entry';
+
+const { babyJub } = require('circomlib');
+const snarkjs = require('snarkjs');
+const utils = require('../utils');
+
+const { bigInt } = snarkjs;
+
+export const CLAIMTYPES = {
+  BASIC: {
+    DEF: 'basic',
+    TYPE: 0,
+  },
+  AUTHORIZE_KSIGN_BABYJUB: {
+    DEF: 'authorizeKSignBabyJub',
+    TYPE: 1,
+  },
+  SET_ROOT_KEY: {
+    DEF: 'setRootKey',
+    TYPE: 2,
+  },
+  ASSIGN_NAME: {
+    DEF: 'assignName',
+    TYPE: 3,
+  },
+  AUTHORIZE_KSIGN_SECP256K1: {
+    DEF: 'authorizeKSignSecp256k1',
+    TYPE: 4,
+  },
+  LINK_OBJECT_IDENTITY: {
+    DEF: 'linkObjectIdentity',
+    TYPE: 5,
+  },
+  AUTHORIZE_ETH_KEY: {
+    DEF: 'authorizeEthKey',
+    TYPE: 9,
+  },
+};
+
+/**
+ * Decode a buffer as number in big endian
+ * @param {Buffer} Buffer
+ * @returns {number}
+ */
+export function buf2num(buf: Buffer): number {
+  return Number(utils.bufferToBigIntBE(buf));
+}
+
+/**
+ * Encode a number as a 4 byte buffer in big endian
+ * @param {number} num
+ * @returns {Buffer}
+ */
+export function num2buf(num: number): Buffer {
+  const buf = Buffer.alloc(4);
+  buf.writeUInt32BE(num, 0);
+  return buf;
+}
+
+/**
+ * Encode a number as a 2 byte buffer in big endian
+ * @param {number} num
+ * @returns {Buffer}
+ */
+export function num2buf2(num: number): Buffer {
+  const buf = Buffer.alloc(2);
+  buf.writeUInt16BE(num, 0);
+  return buf;
+}
+
+/**
+ * Hash a string for a claim
+ * @param {string} elem
+ * @returns {Buffer} hash
+ */
+export function hashString(s: string): Buffer {
+  return utils.hashBytes(Buffer.from(s, 'utf8')).slice(1);
+}
+
+/**
+ * Copy a buffer to an entry element ending at position start
+ * @param {Buffer} elem
+ * @param {number} start
+ * @param {Buffer} src
+ */
+export function copyToElemBuf(elem: Buffer, start: number, src: Buffer) {
+  elem.fill(src, 32 - start - src.length, 32 - start);
+}
+
+/**
+ * Get a buffer from an entry element ending at position start
+ * @param {Buffer} elem
+ * @param {number} start
+ * @param {number} length
+ */
+export function getElemBuf(elem: Buffer, start: number, length: number): Buffer {
+  return elem.slice(32 - start - length, 32 - start);
+}
+
+/**
+ * Set the most significant byte to 0 (in big endian)
+ * @param {Buffer} elem - elem in big endian
+ * @returns {Buffer} hash with the first byte set to 0
+ */
+export function clearElemMostSignificantByte(elem: Buffer): Buffer {
+  return elem.fill(0, 0, 1);
+}
+
+/**
+ * Check element in big endian must be less than claim element field
+ * @param {Buffer} elem - elem in big endian
+ * @throws {Error} throws an error when the check fails
+ */
+export function checkElemFitsClaim(elem: Buffer) {
+  if (elem.length !== 32) {
+    throw new Error('Element is not 32 bytes length');
+  }
+  const elemBigInt = utils.bufferToBigIntBE(elem);
+  if (elemBigInt.greater(babyJub.p)) {
+    throw new Error('Element does not fit on claim element size');
+  }
+}
+
+/**
+ * Check element in big endian must be length size specified
+ * @param {Buffer} elem - elem in big endian
+ * @param {Number} len - length that elem should be
+ * @throws {Error} throws an error when the check fails
+ */
+export function checkByteLen(elem: Buffer, len: number) {
+  if (elem.length !== len) {
+    throw new Error(`Element is not ${len} bytes length`);
+  }
+}
+
+/**
+ * Set the claim type and version of an entry
+ * @param {Object} entry - Entry of the claim
+ * @param {number} claimType
+ * @param {number} version
+ */
+export function setClaimTypeVersion(entry: Entry, claimType: number, version: number) {
+  const claimTypeBuf = utils.bigIntToBufferBE(bigInt(claimType)).slice(24, 32);
+  copyToElemBuf(entry.elements[3], 0, claimTypeBuf);
+  copyToElemBuf(entry.elements[3], 8, num2buf(version));
+}
+
+/**
+ * get the claim type and version of an entry
+ * @param {Object} entry - Entry of the claim
+ * @returns {Object} type and version
+ */
+export function getClaimTypeVersion(entry: Entry): { claimType: number, version: number } {
+  return {
+    claimType: buf2num(getElemBuf(entry.elements[3], 0, 8)),
+    version: buf2num(getElemBuf(entry.elements[3], 8, 4)),
+  };
+}
+
+/**
+ * Increase `version` data field by 1
+ * @param {Entry} claim - Claim to increase its version value
+ */
+export function incClaimVersion(claim: Entry) {
+  const version = claim.elements[3].slice(20, 24).readUInt32BE(0);
+  claim.elements[3].writeUInt32BE(version + 1, claim.elements[3].length - 64 / 8 - 32 / 8);
+}

--- a/src/claim/claim-utils.test.js
+++ b/src/claim/claim-utils.test.js
@@ -5,6 +5,7 @@ import { Entry } from './entry';
 const chai = require('chai');
 const snarkjs = require('snarkjs');
 const { babyJub } = require('circomlib');
+const claimUtils = require('./claim-utils');
 const claim = require('./claim');
 const utils = require('../utils');
 
@@ -21,7 +22,7 @@ describe('[claim-utils]', () => {
                      + '0000000000000000000000000000000000004d59000000010000000000000004';
     const entry = Entry.newFromHex(entryHex);
     // increase version
-    claim.incClaimVersion(entry);
+    claimUtils.incClaimVersion(entry);
     const claimExample = claim.newClaimFromEntry(entry);
     expect(claimExample).to.be.not.equal(undefined);
     if (claimExample == null) { return; }
@@ -31,12 +32,12 @@ describe('[claim-utils]', () => {
 
   it('Clear most significant byte', () => {
     const testIn = '0xf6f36d94c84a7096c572b83d44df576e1ffb3573123f62099f8d4fa19de806bd';
-    const testOutBuff = claim.clearElemMostSignificantByte(utils.hexToBytes(testIn));
+    const testOutBuff = claimUtils.clearElemMostSignificantByte(utils.hexToBytes(testIn));
     const testInSim = '0x00f36d94c84a7096c572b83d44df576e1ffb3573123f62099f8d4fa19de806bd';
     expect(testInSim).to.be.equal(utils.bytesToHex(testOutBuff));
 
     const testIn2 = '0x00f36d94c84a7096c572b83d44df576e1ffb3573123f62099f8d4fa19de806bd';
-    const testOutBuff2 = claim.clearElemMostSignificantByte(utils.hexToBytes(testIn2));
+    const testOutBuff2 = claimUtils.clearElemMostSignificantByte(utils.hexToBytes(testIn2));
     expect(testIn2).to.be.equal(utils.bytesToHex(testOutBuff2));
   });
 
@@ -44,17 +45,17 @@ describe('[claim-utils]', () => {
     // Check hash is more than 32 bytes
     const hash0 = '0xf6a4f36d94c84a7096c572b83d44df576e1ffb3573123f62099f8d4fa19de806bd';
     expect(() => {
-      claim.checkElemFitsClaim(utils.hexToBytes(hash0));
+      claimUtils.checkElemFitsClaim(utils.hexToBytes(hash0));
     }).to.throw('Element is not 32 bytes length');
     // Check hash is not valid for claim field
     const hash1 = '0xf6f36d94c84a7096c572b83d44df576e1ffb3573123f62099f8d4fa19de806bd';
     expect(() => {
-      claim.checkElemFitsClaim(utils.hexToBytes(hash1));
+      claimUtils.checkElemFitsClaim(utils.hexToBytes(hash1));
     }).to.throw('Element does not fit on claim element size');
     // Check hash is valid
     const hash2 = '0x06f36d94c84a7096c572b83d44df576e1ffb3573123f62099f8d4fa19de806bd';
     expect(() => {
-      claim.checkElemFitsClaim(utils.hexToBytes(hash2));
+      claimUtils.checkElemFitsClaim(utils.hexToBytes(hash2));
     }).not.to.throw();
   });
 
@@ -63,10 +64,10 @@ describe('[claim-utils]', () => {
     const test = babyJub.p;
     const test1 = test.add(bigInt(1));
     expect(() => {
-      claim.checkElemFitsClaim(utils.bigIntToBufferBE(test));
+      claimUtils.checkElemFitsClaim(utils.bigIntToBufferBE(test));
     }).not.to.throw();
     expect(() => {
-      claim.checkElemFitsClaim(utils.bigIntToBufferBE(test1));
+      claimUtils.checkElemFitsClaim(utils.bigIntToBufferBE(test1));
     }).to.throw('Element does not fit on claim element size');
   });
 });

--- a/src/claim/claim.js
+++ b/src/claim/claim.js
@@ -8,6 +8,8 @@ import { Basic } from './claim-basic';
 import { SetRootKey } from './claim-set-root-key';
 import { AuthorizeEthKey, ETH_KEY_TYPE } from './claim-authorize-eth-key';
 
+const claimUtils = require('./claim-utils');
+
 export {
   Entry,
   AssignName,
@@ -19,164 +21,8 @@ export {
   SetRootKey,
   AuthorizeEthKey,
   ETH_KEY_TYPE,
+  claimUtils,
 };
-
-const { babyJub } = require('circomlib');
-const snarkjs = require('snarkjs');
-const utils = require('../utils');
-
-const { bigInt } = snarkjs;
-
-export const CLAIMTYPES = {
-  BASIC: {
-    DEF: 'basic',
-    TYPE: 0,
-  },
-  AUTHORIZE_KSIGN_BABYJUB: {
-    DEF: 'authorizeKSignBabyJub',
-    TYPE: 1,
-  },
-  SET_ROOT_KEY: {
-    DEF: 'setRootKey',
-    TYPE: 2,
-  },
-  ASSIGN_NAME: {
-    DEF: 'assignName',
-    TYPE: 3,
-  },
-  AUTHORIZE_KSIGN_SECP256K1: {
-    DEF: 'authorizeKSignSecp256k1',
-    TYPE: 4,
-  },
-  LINK_OBJECT_IDENTITY: {
-    DEF: 'linkObjectIdentity',
-    TYPE: 5,
-  },
-  AUTHORIZE_ETH_KEY: {
-    DEF: 'authorizeEthKey',
-    TYPE: 9,
-  },
-};
-
-/**
- * Decode a buffer as number in big endian
- * @param {Buffer} Buffer
- * @returns {number}
- */
-export function buf2num(buf: Buffer): number {
-  return Number(utils.bufferToBigIntBE(buf));
-}
-
-/**
- * Encode a number as a 4 byte buffer in big endian
- * @param {number} num
- * @returns {Buffer}
- */
-export function num2buf(num: number): Buffer {
-  const buf = Buffer.alloc(4);
-  buf.writeUInt32BE(num, 0);
-  return buf;
-}
-
-/**
- * Encode a number as a 2 byte buffer in big endian
- * @param {number} num
- * @returns {Buffer}
- */
-export function num2buf2(num: number): Buffer {
-  const buf = Buffer.alloc(2);
-  buf.writeUInt16BE(num, 0);
-  return buf;
-}
-
-/**
- * Hash a string for a claim
- * @param {string} elem
- * @returns {Buffer} hash
- */
-export function hashString(s: string): Buffer {
-  return utils.hashBytes(Buffer.from(s, 'utf8')).slice(1);
-}
-
-/**
- * Copy a buffer to an entry element ending at position start
- * @param {Buffer} elem
- * @param {number} start
- * @param {Buffer} src
- */
-export function copyToElemBuf(elem: Buffer, start: number, src: Buffer) {
-  elem.fill(src, 32 - start - src.length, 32 - start);
-}
-
-/**
- * Get a buffer from an entry element ending at position start
- * @param {Buffer} elem
- * @param {number} start
- * @param {number} length
- */
-export function getElemBuf(elem: Buffer, start: number, length: number): Buffer {
-  return elem.slice(32 - start - length, 32 - start);
-}
-
-/**
- * Set the most significant byte to 0 (in big endian)
- * @param {Buffer} elem - elem in big endian
- * @returns {Buffer} hash with the first byte set to 0
- */
-export function clearElemMostSignificantByte(elem: Buffer): Buffer {
-  return elem.fill(0, 0, 1);
-}
-
-/**
- * Check element in big endian must be less than claim element field
- * @param {Buffer} elem - elem in big endian
- * @throws {Error} throws an error when the check fails
- */
-export function checkElemFitsClaim(elem: Buffer) {
-  if (elem.length !== 32) {
-    throw new Error('Element is not 32 bytes length');
-  }
-  const elemBigInt = utils.bufferToBigIntBE(elem);
-  if (elemBigInt.greater(babyJub.p)) {
-    throw new Error('Element does not fit on claim element size');
-  }
-}
-
-/**
- * Check element in big endian must be length size specified
- * @param {Buffer} elem - elem in big endian
- * @param {Number} len - length that elem should be
- * @throws {Error} throws an error when the check fails
- */
-export function checkByteLen(elem: Buffer, len: number) {
-  if (elem.length !== len) {
-    throw new Error(`Element is not ${len} bytes length`);
-  }
-}
-
-/**
- * Set the claim type and version of an entry
- * @param {Object} entry - Entry of the claim
- * @param {number} claimType
- * @param {number} version
- */
-export function setClaimTypeVersion(entry: Entry, claimType: number, version: number) {
-  const claimTypeBuf = utils.bigIntToBufferBE(bigInt(claimType)).slice(24, 32);
-  copyToElemBuf(entry.elements[3], 0, claimTypeBuf);
-  copyToElemBuf(entry.elements[3], 8, num2buf(version));
-}
-
-/**
- * get the claim type and version of an entry
- * @param {Object} entry - Entry of the claim
- * @returns {Object} type and version
- */
-export function getClaimTypeVersion(entry: Entry): { claimType: number, version: number } {
-  return {
-    claimType: buf2num(getElemBuf(entry.elements[3], 0, 8)),
-    version: buf2num(getElemBuf(entry.elements[3], 8, 4)),
-  };
-}
 
 /**
  * Decode entry class into claim data structure depending on its type
@@ -186,33 +32,24 @@ export function getClaimTypeVersion(entry: Entry): { claimType: number, version:
 // eslint-disable-next-line max-len
 export function newClaimFromEntry(entry: Entry): void | Basic | AuthorizeKSignBabyJub | SetRootKey | AssignName | AuthorizeKSignSecp256k1 | LinkObjectIdentity | AuthorizeEthKey {
   // Decode claim type from Entry class
-  const { claimType } = getClaimTypeVersion(entry);
+  const { claimType } = claimUtils.getClaimTypeVersion(entry);
   // Parse elements and return the proper claim structure
   switch (claimType) {
-    case CLAIMTYPES.BASIC.TYPE:
+    case claimUtils.CLAIMTYPES.BASIC.TYPE:
       return Basic.newFromEntry(entry);
-    case CLAIMTYPES.AUTHORIZE_KSIGN_BABYJUB.TYPE:
+    case claimUtils.CLAIMTYPES.AUTHORIZE_KSIGN_BABYJUB.TYPE:
       return AuthorizeKSignBabyJub.newFromEntry(entry);
-    case CLAIMTYPES.SET_ROOT_KEY.TYPE:
+    case claimUtils.CLAIMTYPES.SET_ROOT_KEY.TYPE:
       return SetRootKey.newFromEntry(entry);
-    case CLAIMTYPES.ASSIGN_NAME.TYPE:
+    case claimUtils.CLAIMTYPES.ASSIGN_NAME.TYPE:
       return AssignName.newFromEntry(entry);
-    case CLAIMTYPES.AUTHORIZE_KSIGN_SECP256K1.TYPE:
+    case claimUtils.CLAIMTYPES.AUTHORIZE_KSIGN_SECP256K1.TYPE:
       return AuthorizeKSignSecp256k1.newFromEntry(entry);
-    case CLAIMTYPES.LINK_OBJECT_IDENTITY.TYPE:
+    case claimUtils.CLAIMTYPES.LINK_OBJECT_IDENTITY.TYPE:
       return LinkObjectIdentity.newFromEntry(entry);
-    case CLAIMTYPES.AUTHORIZE_ETH_KEY.TYPE:
+    case claimUtils.CLAIMTYPES.AUTHORIZE_ETH_KEY.TYPE:
       return AuthorizeEthKey.newFromEntry(entry);
     default:
       throw new Error(`Unknown claim type ${claimType}`);
   }
-}
-
-/**
- * Increase `version` data field by 1
- * @param {Entry} claim - Claim to increase its version value
- */
-export function incClaimVersion(claim: Entry) {
-  const version = claim.elements[3].slice(20, 24).readUInt32BE(0);
-  claim.elements[3].writeUInt32BE(version + 1, claim.elements[3].length - 64 / 8 - 32 / 8);
 }

--- a/src/claim/entry.js
+++ b/src/claim/entry.js
@@ -1,14 +1,30 @@
 // @flow
 import { getArrayBigIntFromBuffArrayBE, bigIntToBufferBE } from '../utils';
 
+const { babyJub } = require('circomlib');
 const snarkjs = require('snarkjs');
 const utils = require('../utils');
 const mimc7 = require('../sparse-merkle-tree/mimc7');
-const claimUtils = require('./claim');
 
 const { bigInt } = snarkjs;
 
 const entryElemsLen = 4;
+
+// TODO: Reorganize claim-utils to avoid cycle dependencies
+/**
+ * Check element in big endian must be less than claim element field
+ * @param {Buffer} elem - elem in big endian
+ * @throws {Error} throws an error when the check fails
+ */
+function checkElemFitsClaim(elem: Buffer) {
+  if (elem.length !== 32) {
+    throw new Error('Element is not 32 bytes length');
+  }
+  const elemBigInt = utils.bufferToBigIntBE(elem);
+  if (elemBigInt.greater(babyJub.p)) {
+    throw new Error('Element does not fit on claim element size');
+  }
+}
 
 /**
  * Generic representation of claim elements
@@ -19,10 +35,10 @@ export class Entry {
   elements: Array<Buffer>;
 
   constructor(e0: Buffer, e1: Buffer, e2: Buffer, e3: Buffer) {
-    claimUtils.checkElemFitsClaim(e0);
-    claimUtils.checkElemFitsClaim(e1);
-    claimUtils.checkElemFitsClaim(e2);
-    claimUtils.checkElemFitsClaim(e3);
+    checkElemFitsClaim(e0);
+    checkElemFitsClaim(e1);
+    checkElemFitsClaim(e2);
+    checkElemFitsClaim(e3);
     this.elements = [e0, e1, e2, e3];
   }
 

--- a/src/crypto/crypto.js
+++ b/src/crypto/crypto.js
@@ -1,5 +1,7 @@
 const utilsBabyJub = require('./babyjub-utils');
+const eddsaBabyJub = require('./eddsa-babyjub');
 
 module.exports = {
   utilsBabyJub,
+  eddsaBabyJub,
 };

--- a/src/crypto/eddsa-babyjub.js
+++ b/src/crypto/eddsa-babyjub.js
@@ -1,6 +1,7 @@
 // @flow
 
 const crypto = require('crypto');
+const createBlakeHash = require('blake-hash');
 const { babyJub, eddsa } = require('circomlib');
 const { bigInt } = require('snarkjs');
 
@@ -154,6 +155,16 @@ export class PrivateKey {
    */
   public(): PublicKey {
     return new PublicKey(eddsa.prv2pub(this.sk));
+  }
+
+  /**
+   * Retrieve private scalar of the PrivateKey
+   * @returns {bigInt} Prvate scalar derived from PrivateKey
+   */
+  toPrivScalar(): bigInt {
+    const h1 = createBlakeHash('blake512').update(this.sk).digest();
+    const sBuff = eddsa.pruneBuffer(h1.slice(0, 32));
+    return (bigInt.leBuff2int(sBuff)).shr(3);
   }
 
   /**

--- a/src/crypto/eddsa-babyjub.test.js
+++ b/src/crypto/eddsa-babyjub.test.js
@@ -6,6 +6,7 @@ const chai = require('chai');
 const { bigInt } = require('snarkjs');
 const eddsa = require('./eddsa-babyjub.js');
 const utils = require('../utils');
+const utilsBabyJub = require('./babyjub-utils.js');
 
 const { expect } = chai;
 
@@ -47,5 +48,12 @@ describe('[eddsa babyjyb]', () => {
       + '0dab19c5a0a75973cd75a54780de0c3a41ede6f57396fe99b5307fff3ce7cc04');
     const sig2 = eddsa.Signature.newFromCompressed(sigComp);
     expect(pk.verifyMimc7(msg, sig2)).to.be.equal(true);
+  });
+
+  it('scalar', () => {
+    const privKeyBuff = utils.hexToBytes(skHex);
+    const scalarPriv1 = utilsBabyJub.privToScalar(privKeyBuff);
+    const scalarPriv2 = sk.toPrivScalar();
+    expect(scalarPriv1.toString()).to.be.equal(scalarPriv2.toString());
   });
 });

--- a/src/protocols/proofs.js
+++ b/src/protocols/proofs.js
@@ -9,7 +9,7 @@ const snarkjs = require('snarkjs');
 const utils = require('../utils');
 const mtHelpers = require('../sparse-merkle-tree/sparse-merkle-tree-utils');
 const sparsemerkletree = require('../sparse-merkle-tree/sparse-merkle-tree');
-const claimUtils = require('../claim/claim');
+const claimUtils = require('../claim/claim-utils');
 const smt = require('../sparse-merkle-tree/sparse-merkle-tree');
 
 const { SparseMerkleTree } = sparsemerkletree;

--- a/src/sparse-merkle-tree/sparse-merkle-tree.js
+++ b/src/sparse-merkle-tree/sparse-merkle-tree.js
@@ -1,5 +1,5 @@
 import * as helpers from './sparse-merkle-tree-utils';
-import { Entry } from '../claim/entry';
+import { Entry } from '../claim/claim';
 
 const snarkjs = require('snarkjs');
 const utils = require('../utils');


### PR DESCRIPTION
- `claim.js` used only to export all claim functions

- `claim-utils.js` has all claim helpers functions